### PR TITLE
TakerTraits builder indexes fix

### DIFF
--- a/src/libs/TakerTraits.sol
+++ b/src/libs/TakerTraits.sol
@@ -115,7 +115,7 @@ library TakerTraitsLib {
         uint256 index0 = args.threshold.length;
         uint256 index1 = (index0 + (args.to != address(0) && args.to != args.taker ? 20 : 0));
         uint256 index2 = (index1 + (args.deadline != 0 ? 5 : 0));
-        uint256 index3 = (index2 + args.preTransferInHookData.length.toUint16());
+        uint256 index3 = (index2 + args.preTransferInHookData.length).toUint16();
         uint256 index4 = (index3 + args.postTransferInHookData.length).toUint16();
         uint256 index5 = (index4 + args.preTransferOutHookData.length).toUint16();
         uint256 index6 = (index5 + args.postTransferOutHookData.length).toUint16();


### PR DESCRIPTION
## Change Summary
Fix minor bug in `TakerTraits:build` function leading to errors in `slicesIndexes` table in `TakerTraits` in case `index2 + preTransferInHookData` exceeds `2 ** 16` bytes.

## Risk Assessment
**Risk Level:**
- [x] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback
