### PR TITLE
chore(skills): bring release/1.0.1 to parity with the skill set from #167

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -20,6 +20,11 @@ every skill added here costs context on every request.
 | `solidity-auditor` | Pashov Audit Group | Runs a fan-out audit over `src/`. Its `math-precision`, `asymmetry`, `boundary` and `invariant` passes line up with the properties already listed in `.cursor/rules/security-review.mdc`, and its bit-mask checks apply to `MakerTraits` and `TakerTraits`. |
 | `property-based-testing` | Trail of Bits | `test/invariants/` already holds 20+ suites; this covers property design, generator strategies and reading shrunk counterexamples. |
 | `differential-review` | Trail of Bits | Security-focused review of a diff rather than a snapshot, including blast radius and test-coverage checks. Complements the generic prompt in `.github/workflows/claude-code-review.yml`. |
+| `hardhat` | Nomic Foundation | Carried for parity with `main`, which is Hardhat-first. This branch is Foundry-only — no `hardhat.config.ts`, and `package.json` runs `forge test` / `forge build` — so the skill has nothing to match on and stays dormant here. It becomes useful if this branch ever picks up the Hardhat 3 setup that landed in #138 and #161. |
+
+The two `hardhat-toolbox-*` companion skills are deliberately absent. They cover
+`@nomicfoundation/hardhat-toolbox-viem` and `@nomicfoundation/hardhat-toolbox-mocha-ethers`, neither
+of which this repo uses.
 
 ## Evaluated and skipped
 
@@ -33,8 +38,8 @@ every skill added here costs context on every request.
 
 ## Licensing
 
-The Trail of Bits skills are CC BY-SA 4.0 and the Pashov skill is MIT; both are recorded in
-`THIRD_PARTY_NOTICES`. Keep the vendored files verbatim. Editing them in place produces Adapted
+The Trail of Bits skills are CC BY-SA 4.0, the Pashov skill is MIT and the Hardhat skill is ISC; all
+three are recorded in `THIRD_PARTY_NOTICES`. Keep the vendored files verbatim. Editing them in place produces Adapted
 Material under ShareAlike — put repo-specific guidance in `.cursor/rules/` instead, which is where
 `security-review.mdc`, `foundry-tests.mdc` and `solidity-style.mdc` already live.
 

--- a/.agents/skills/hardhat/SKILL.md
+++ b/.agents/skills/hardhat/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: hardhat
+description: Use when working with Hardhat 3 projects — writing or modifying Solidity tests, TypeScript tests, or any code touching hardhat.config.ts, the `hardhat` import, or `network.create()`. Covers test-layer choice, forge-std cheatcodes, the network connection API, `networkHelpers`, and the compile-then-typecheck workflow. For toolbox-specific guidance (clients, contract calls, assertions), also load the matching `hardhat-toolbox-*` skill.
+metadata:
+  package: "hardhat"
+---
+
+# Hardhat 3
+
+This skill covers Hardhat 3 itself. The toolbox layer (clients, contract interaction, ecosystem-specific assertions) lives in companion skills — load whichever matches the project:
+
+- `@nomicfoundation/hardhat-toolbox-viem` → also load the **`hardhat-toolbox-viem`** skill.
+- `@nomicfoundation/hardhat-toolbox-mocha-ethers` → also load the **`hardhat-toolbox-mocha-ethers`** skill.
+
+## Test organization
+
+Hardhat 3 supports two distinct test layers:
+
+**Solidity tests** (`.t.sol` files in `contracts/`, or any `.sol` file in `test/`) are the default choice for unit tests on individual contracts. They run directly in the EVM, compile-check against the real ABI, and have access to cheatcodes for EVM state manipulation. Any public function whose name starts with `test` is executed as a test case.
+
+**TypeScript tests** (`.ts` files in `test/`) are the right choice when a test requires off-chain orchestration: multi-contract interactions, fixture reuse across a large suite, assertions about gas or ETH balances from the outside, or integration scenarios driven by external state.
+
+Reach for TypeScript only when Solidity isn't enough. Solidity tests cover all contract logic; TypeScript tests cover the end-to-end flow as a user or script would experience it.
+
+```bash
+hardhat test            # run all tests (Solidity + TypeScript)
+hardhat test solidity   # Solidity tests only
+```
+
+TypeScript tests are run either with `hardhat test nodejs` or with `hardhat test mocha`, depending on the toolbox or plugins being used: the viem-based toolbox uses `nodejs` while the ethers+mocha toolbox uses `mocha`.
+
+Pass `--coverage` to collect Solidity coverage while running tests. It works on the main `hardhat test` task as well as the `solidity` and TypeScript subtasks (`nodejs` / `mocha`), so you can scope coverage to a single test layer when needed.
+
+## Solidity tests
+
+Any contract that contains at least one `test*` function is treated as a test contract. Use `forge-std` (if present in `package.json`) for assertions and cheatcodes:
+
+```solidity
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+import { Counter } from "./Counter.sol";
+
+contract CounterTest is Test {
+  Counter counter;
+
+  function setUp() public {
+    counter = new Counter();
+  }
+
+  function test_InitialValueIsZero() public view {
+    assertEq(counter.x(), 0);
+  }
+
+  function test_IncByIncreasesByAmount() public {
+    counter.incBy(3);
+    assertEq(counter.x(), 3);
+  }
+
+  // Fuzz test: Hardhat runs this with many random inputs automatically
+  function testFuzz_Inc(uint8 x) public {
+    for (uint8 i = 0; i < x; i++) {
+      counter.inc();
+    }
+    require(counter.x() == x, "Value after calling inc x times should be x");
+  }
+}
+```
+
+The `vm` object (from `forge-std/Test.sol`) exposes cheatcodes for EVM state manipulation. Commonly used ones:
+
+| Cheatcode | Effect |
+| --- | --- |
+| `vm.prank(addr)` | Sets `msg.sender` for the next call only |
+| `vm.startPrank(addr)` / `vm.stopPrank()` | Sets `msg.sender` for a range of calls |
+| `vm.deal(addr, amount)` | Sets an account's ETH balance |
+| `vm.warp(timestamp)` | Sets `block.timestamp` |
+| `vm.roll(blockNum)` | Sets `block.number` |
+| `vm.expectRevert(...)` | Asserts the next call reverts |
+| `vm.expectEmit(...)` | Asserts the next call emits a specific event |
+
+## TypeScript tests and the network connection
+
+The central object in a TypeScript test is the **network connection**, created by `network.create()`. Toolbox plugins extend it with helper objects (e.g. `viem` or `ethers`, plus `networkHelpers`):
+
+```ts
+import { network } from "hardhat";
+
+const { networkHelpers } = await network.create();
+// Toolbox plugins also expose viem / ethers on this object;
+// see the matching hardhat-toolbox-* skill.
+```
+
+Hardhat 3 only works with ESM, so top-level `await` is available. Each call to `network.create()` produces an **isolated blockchain state**. A top-level network connection can be used when the same connection and its associated state can be shared across all tests in the file. For more isolation, you can create a new connection for each test suite or even each test case.
+
+### `networkHelpers`: EVM state manipulation
+
+`networkHelpers` wraps all of Hardhat's development-only helpers behind a typed, ergonomic API. Prefer it over raw JSON-RPC calls:
+
+```ts
+// Time
+await networkHelpers.time.increase(60); // mine a block 60 s ahead
+await networkHelpers.time.increaseTo(target); // mine to a specific timestamp
+const now = await networkHelpers.time.latest(); // latest block timestamp
+await networkHelpers.time.setNextBlockTimestamp(ts); // set without mining
+
+// Blocks
+await networkHelpers.mine(); // mine one block
+await networkHelpers.mine(5); // mine several blocks
+
+// Accounts
+await networkHelpers.impersonateAccount(addr);
+await networkHelpers.setBalance(addr, 10n ** 18n);
+
+// Block parameters
+await networkHelpers.setPrevRandao(value); // set block.prevrandao for the next block
+await networkHelpers.setNextBlockBaseFeePerGas(baseFee);
+
+// Fixtures
+//
+// loadFixture runs the setup once and snapshots the state. Subsequent calls
+// restore the snapshot instead of re-deploying, much faster for large suites.
+// The deploy step inside the fixture is toolbox-specific (e.g.
+// viem.deployContract, an ethers ContractFactory) — see the matching
+// hardhat-toolbox-* skill.
+async function deployCounter() {
+  // ... toolbox-specific deploy ...
+  return { counter };
+}
+
+const { counter } = await networkHelpers.loadFixture(deployCounter);
+// loadFixture requires a named function for caching to work (not an
+// arrow/anonymous function)
+
+// Snapshots (manual)
+const snap = await networkHelpers.takeSnapshot();
+// ... do things ...
+await snap.restore();
+```
+
+For plain TypeScript assertions (equality, arrays, types), use `node:assert/strict`. For ecosystem-specific assertions (reverts, events, balance changes), see the matching `hardhat-toolbox-*` skill.
+
+## Typechecking
+
+Generated contract types are derived from the compiled ABI (viem in the viem toolbox, TypeChain in the ethers toolbox), so recompile first, then typecheck. The example below uses npm; swap `npx` for whichever package manager runner this project uses:
+
+```bash
+npx hardhat build && npx tsc --noEmit
+```
+
+The compiler will catch wrong argument types, missing arguments, and invalid options (e.g. `value` on a non-payable function) before you even start the test runner. Make this a habit: it surfaces many mistakes faster than running the full test suite.

--- a/LICENSES/ISC-Nomic-Hardhat-Skills.txt
+++ b/LICENSES/ISC-Nomic-Hardhat-Skills.txt
@@ -1,0 +1,21 @@
+ISC License
+
+Copyright (c) Nomic Foundation
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+Note: https://github.com/NomicFoundation/hardhat-skills declares "license":
+"ISC" in its package.json but ships no LICENSE file. The text above is the
+standard ISC license text, reproduced here to satisfy the notice requirement.

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -66,3 +66,15 @@ Notes: Documentation only, reproduced verbatim under /.agents/skills/ as
        solidity-auditor (skill VERSION 3).
 
 ================================================================================
+
+Component: Nomic Foundation Hardhat agent skills
+Repo: https://github.com/NomicFoundation/hardhat-skills
+Version: 2f1530cca5e97e319d4edb6f2f552cf7ce922258
+License: ISC
+Copyright: © Nomic Foundation
+License: /LICENSES/ISC-Nomic-Hardhat-Skills.txt
+Notes: Documentation only, reproduced verbatim under /.agents/skills/ as
+       hardhat. Upstream declares ISC in package.json but ships no LICENSE
+       file; see the note in the license text.
+
+================================================================================

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -19,6 +19,12 @@
       "skillPath": "plugins/entry-point-analyzer/skills/entry-point-analyzer/SKILL.md",
       "computedHash": "78dd6cbfce13a600e890d1c8936d85eb9c6e4d8752327bb5954796f6e03f2bd9"
     },
+    "hardhat": {
+      "source": "nomicfoundation/hardhat-skills",
+      "sourceType": "github",
+      "skillPath": "skills/hardhat/SKILL.md",
+      "computedHash": "6a28b7ffc9e215a40b83b46b59fbb81f89e9a472218468df18ae0f042c52b608"
+    },
     "property-based-testing": {
       "source": "trailofbits/skills",
       "sourceType": "github",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Companion to #169, which rolls #167 back off `main`. This puts the same skill set on the v1.0.1 release branch.

There is no branch named `v1.0.1` — only the `v1.0.1` tag and the `release/1.0.1` branch — so this targets `release/1.0.1`, which is where #166 already went.

## The diff is smaller than it looks

#166 already merged six of the seven skills here: `dimensional-analysis`, `token-integration-analyzer`, `entry-point-analyzer`, `property-based-testing`, `differential-review` and `solidity-auditor`. The only thing #167 added on top was `nomicfoundation/hardhat-skills@hardhat`, so that is what this PR brings over, along with its licence records.

Everything vendored is byte-identical to what #167 delivered:

```
$ git diff --name-status a916fa7 -- .agents skills-lock.json LICENSES THIRD_PARTY_NOTICES .gitignore
M   .agents/skills/README.md
```

The README is the sole difference, and deliberately so — see below.

## One thing worth deciding before merging

**The `hardhat` skill does not apply to this branch.** `release/1.0.1` is Foundry-only: there is no `hardhat.config.ts`, and `package.json` runs `forge test` / `forge build` / `forge fmt`. The skill's own description scopes it to "Hardhat 3 projects — ... any code touching `hardhat.config.ts`, the `hardhat` import, or `network.create()`", none of which exist here.

In practice it will sit dormant, since an agent only loads a skill body when the task matches its description. But it is dead weight in context, and there is a small risk of it nudging an agent toward `hardhat test solidity` when the branch wants `forge test`.

I have not repeated #167's README text here, because that version described the repo as Hardhat-first — true for `main`, false for this branch. The README instead records that the skill is carried for parity and is inert here.

If you would rather leave it off, it is one command:

```bash
npx skills remove hardhat -a cursor
```

and then drop `LICENSES/ISC-Nomic-Hardhat-Skills.txt` and its `THIRD_PARTY_NOTICES` entry. Say the word and I will push that instead.

## Verification

```
$ npx skills list
differential-review         ./.agents/skills/differential-review
dimensional-analysis        ./.agents/skills/dimensional-analysis
entry-point-analyzer        ./.agents/skills/entry-point-analyzer
hardhat                     ./.agents/skills/hardhat
property-based-testing      ./.agents/skills/property-based-testing
solidity-auditor            ./.agents/skills/solidity-auditor
token-integration-analyzer  ./.agents/skills/token-integration-analyzer
```

All seven validate — the `name` in each `SKILL.md` frontmatter matches its directory — and the set is identical to #167's. The `hardhat` skill scanned clean (Safe, 0 Socket alerts, Low Risk). No Solidity is touched, so the build and test path is unaffected.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac5d753f-aba2-44dd-a47a-42f21c7a7e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac5d753f-aba2-44dd-a47a-42f21c7a7e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

