### PR TITLE
fix: best-effort protocol fee charging so failed fees never block swaps

### DIFF
--- a/src/instructions/Fee.sol
+++ b/src/instructions/Fee.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.30;
 /// @custom:copyright © 2025 Degensoft Ltd
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@1inch/solidity-utils/contracts/libraries/SafeERC20.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { IAqua } from "@1inch/aqua/src/interfaces/IAqua.sol";
 
@@ -54,13 +53,20 @@ library FeeArgsBuilder {
 }
 
 contract Fee {
-    using SafeERC20 for IERC20;
     using ContextLib for Context;
 
     error FeeShouldBeAppliedBeforeSwapAmountsComputation();
     error FeeDynamicProtocolInvalidRecipient();
     error FeeBpsOutOfRange(uint256 feeBps);
     error FeeProtocolProviderFailedCall();
+
+    /// @notice Emitted when a protocol fee transfer fails and the fee is skipped.
+    /// @dev Fee charging is best-effort: a failed transfer never blocks the swap.
+    /// @param orderHash Unique identifier for the order/strategy
+    /// @param token Token in which the fee was to be charged (tokenIn)
+    /// @param feeAmount Fee amount that failed to transfer
+    /// @param to Intended fee recipient
+    event FeeChargeFailed(bytes32 orderHash, address token, uint256 feeAmount, address to);
 
     IAqua internal immutable _AQUA;
 
@@ -87,56 +93,64 @@ contract Fee {
         }
     }
 
-    /// @notice Protocol fee on amountIn — transfers fee from maker to recipient via safeTransferFrom.
-    /// @dev IMPORTANT: The maker MUST already hold sufficient tokenIn balance and have approved this contract
-    ///   BEFORE the swap is executed. The fee transfer occurs during program execution (inside runLoop),
-    ///   which is before SwapVM completes the taker→maker tokenIn transfer. If the maker lacks tokenIn
-    ///   balance or allowance, the swap will revert.
-    /// @dev QUOTE/SWAP DIVERGENCE: In quote mode (isStaticContext=true), this instruction computes the fee
-    ///   but skips the actual token transfer. Quote may succeed while swap reverts due to insufficient
-    ///   balance or missing approval. Makers MUST NOT use backward jumps to this instruction as it may
-    ///   break numerical consistency between quote() and swap().
+    /// @notice Protocol fee on amountIn — transfers fee from maker to recipient via transferFrom.
+    /// @dev BEST-EFFORT CHARGING: The fee transfer occurs during program execution (inside runLoop),
+    ///   which is before SwapVM completes the taker→maker tokenIn transfer. If the transfer fails
+    ///   (e.g. the maker lacks tokenIn balance or allowance at that point), the fee is skipped,
+    ///   FeeChargeFailed is emitted and the swap proceeds — fees never block a swap. The skipped
+    ///   fee simply remains uncollected. Monitor FeeChargeFailed off-chain.
+    /// @dev Amounts are computed identically in quote and swap modes; in quote mode
+    ///   (isStaticContext=true) the actual token transfer is skipped. Makers MUST NOT use backward
+    ///   jumps to this instruction as it may break numerical consistency between quote() and swap().
     /// @param args.feeBps | 4 bytes (fee in bps, 1e9 = 100%)
     /// @param args.to     | 20 bytes (address to send pulled tokens to)
     function _protocolFeeAmountInXD(Context memory ctx, bytes calldata args) internal {
         (uint256 feeBps, address to) = FeeArgsBuilder.parseProtocolFee(args);
         uint256 feeAmountIn = _feeAmountIn(ctx, feeBps);
 
-        if (!ctx.vm.isStaticContext) {
-            IERC20(ctx.query.tokenIn).safeTransferFrom(ctx.query.maker, to, feeAmountIn);
+        if (!ctx.vm.isStaticContext && !_tryPullFee(ctx.query.tokenIn, ctx.query.maker, to, feeAmountIn)) {
+            emit FeeChargeFailed(ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to);
         }
     }
 
     /// @notice Protocol fee on amountIn for Aqua — pulls fee from maker's Aqua balance to recipient.
-    /// @dev IMPORTANT: The maker MUST already hold sufficient tokenIn balance in Aqua BEFORE the swap
-    ///   is executed. The fee pull occurs during program execution (inside runLoop), which is before
-    ///   SwapVM completes the taker→maker tokenIn transfer. If the maker's Aqua tokenIn balance is
-    ///   insufficient, the swap will revert.
-    /// @dev QUOTE/SWAP DIVERGENCE: In quote mode (isStaticContext=true), this instruction computes the fee
-    ///   but skips the Aqua pull operation. Quote may succeed while swap reverts due to insufficient
-    ///   Aqua balance. Makers MUST NOT use backward jumps to this instruction as it may break numerical
-    ///   consistency between quote() and swap().
+    /// @dev BEST-EFFORT CHARGING: The fee pull occurs during program execution (inside runLoop),
+    ///   which is before SwapVM completes the taker→maker tokenIn transfer. If the pull fails
+    ///   (e.g. the strategy's tokenIn balance is drained to a range boundary), the fee is skipped,
+    ///   FeeChargeFailed is emitted and the swap proceeds — fees never block a swap. The skipped fee
+    ///   remains in the maker's strategy balance, so a strategy at a range boundary effectively
+    ///   trades fee-free in that direction until rebalanced. Monitor FeeChargeFailed off-chain.
+    /// @dev amountNetPulled is increased only when the pull succeeds, keeping the post-push maker
+    ///   balance check in SwapVM strict when the fee was not actually pulled.
+    /// @dev Amounts are computed identically in quote and swap modes; in quote mode
+    ///   (isStaticContext=true) the Aqua pull is skipped. Makers MUST NOT use backward jumps to
+    ///   this instruction as it may break numerical consistency between quote() and swap().
     /// @param args.feeBps | 4 bytes (fee in bps, 1e9 = 100%)
     /// @param args.to     | 20 bytes (address to send pulled tokens to)
     function _aquaProtocolFeeAmountInXD(Context memory ctx, bytes calldata args) internal {
         (uint256 feeBps, address to) = FeeArgsBuilder.parseProtocolFee(args);
         uint256 feeAmountIn = _feeAmountIn(ctx, feeBps);
-        ctx.swap.amountNetPulled += feeAmountIn;
 
         if (!ctx.vm.isStaticContext) {
-            _AQUA.pull(ctx.query.maker, ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to);
+            try _AQUA.pull(ctx.query.maker, ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to) {
+                ctx.swap.amountNetPulled += feeAmountIn;
+            } catch {
+                emit FeeChargeFailed(ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to);
+            }
+        } else {
+            ctx.swap.amountNetPulled += feeAmountIn;
         }
     }
 
     /// @notice Dynamic protocol fee with external fee provider
-    /// @dev IMPORTANT: The maker MUST already hold sufficient tokenIn balance and have approved this contract
-    ///   BEFORE the swap is executed. The fee transfer occurs during program execution (inside runLoop),
-    ///   which is before SwapVM completes the taker→maker tokenIn transfer. If the maker lacks tokenIn
-    ///   balance or allowance, the swap will revert.
-    /// @dev QUOTE/SWAP DIVERGENCE: In quote mode (isStaticContext=true), this instruction computes the fee
-    ///   but skips the actual token transfer. Quote may succeed while swap reverts due to insufficient
-    ///   balance or missing approval. Makers MUST NOT use backward jumps to this instruction as it may
-    ///   break numerical consistency between quote() and swap().
+    /// @dev BEST-EFFORT CHARGING: The fee transfer occurs during program execution (inside runLoop),
+    ///   which is before SwapVM completes the taker→maker tokenIn transfer. If the transfer fails
+    ///   (e.g. the maker lacks tokenIn balance or allowance at that point), the fee is skipped,
+    ///   FeeChargeFailed is emitted and the swap proceeds — fees never block a swap. The skipped
+    ///   fee simply remains uncollected. Monitor FeeChargeFailed off-chain.
+    /// @dev Amounts are computed identically in quote and swap modes; in quote mode
+    ///   (isStaticContext=true) the actual token transfer is skipped. Makers MUST NOT use backward
+    ///   jumps to this instruction as it may break numerical consistency between quote() and swap().
     /// @dev REENTRANCY SAFETY:
     ///   - Uses staticcall preventing state changes by feeProvider
     ///   - Protected by TransientLock on orderHash level in SwapVM.swap()
@@ -171,21 +185,22 @@ contract Fee {
 
             uint256 feeAmountIn = _feeAmountIn(ctx, feeBps);
 
-            if (!ctx.vm.isStaticContext && feeAmountIn > 0) {
-                IERC20(ctx.query.tokenIn).safeTransferFrom(ctx.query.maker, to, feeAmountIn);
+            if (!ctx.vm.isStaticContext && feeAmountIn > 0 && !_tryPullFee(ctx.query.tokenIn, ctx.query.maker, to, feeAmountIn)) {
+                emit FeeChargeFailed(ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to);
             }
         }
     }
 
     /// @notice Dynamic protocol fee with external fee provider (Aqua version)
-    /// @dev IMPORTANT: The maker MUST already hold sufficient tokenIn balance in Aqua BEFORE the swap
-    ///   is executed. The fee pull occurs during program execution (inside runLoop), which is before
-    ///   SwapVM completes the taker→maker tokenIn transfer. If the maker's Aqua tokenIn balance is
-    ///   insufficient, the swap will revert.
-    /// @dev QUOTE/SWAP DIVERGENCE: In quote mode (isStaticContext=true), this instruction computes the fee
-    ///   but skips the Aqua pull operation. Quote may succeed while swap reverts due to insufficient
-    ///   Aqua balance. Makers MUST NOT use backward jumps to this instruction as it may break numerical
-    ///   consistency between quote() and swap().
+    /// @dev BEST-EFFORT CHARGING: The fee pull occurs during program execution (inside runLoop),
+    ///   which is before SwapVM completes the taker→maker tokenIn transfer. If the pull fails
+    ///   (e.g. the strategy's tokenIn balance is drained to a range boundary), the fee is skipped,
+    ///   FeeChargeFailed is emitted and the swap proceeds — fees never block a swap. The skipped fee
+    ///   remains in the maker's strategy balance. amountNetPulled is increased only when the pull
+    ///   succeeds, keeping the post-push maker balance check in SwapVM strict.
+    /// @dev Amounts are computed identically in quote and swap modes; in quote mode
+    ///   (isStaticContext=true) the Aqua pull is skipped. Makers MUST NOT use backward jumps to
+    ///   this instruction as it may break numerical consistency between quote() and swap().
     /// @dev REENTRANCY SAFETY:
     ///   - Uses staticcall preventing state changes by feeProvider
     ///   - Protected by TransientLock on orderHash level in SwapVM.swap()
@@ -219,15 +234,62 @@ contract Fee {
             require(to != address(0), FeeDynamicProtocolInvalidRecipient());
 
             uint256 feeAmountIn = _feeAmountIn(ctx, feeBps);
-            ctx.swap.amountNetPulled += feeAmountIn;
 
-            if (!ctx.vm.isStaticContext && feeAmountIn > 0) {
-                _AQUA.pull(ctx.query.maker, ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to);
+            if (!ctx.vm.isStaticContext) {
+                if (feeAmountIn > 0) {
+                    try _AQUA.pull(ctx.query.maker, ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to) {
+                        ctx.swap.amountNetPulled += feeAmountIn;
+                    } catch {
+                        emit FeeChargeFailed(ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to);
+                    }
+                }
+            } else {
+                ctx.swap.amountNetPulled += feeAmountIn;
             }
         }
     }
 
     // Internal functions
+
+    /// @notice Attempts to transfer a protocol fee from the maker without reverting on failure.
+    /// @dev Non-reverting ERC20 transferFrom used for best-effort fee charging: callers skip
+    ///   the fee (and emit FeeChargeFailed) when this returns false, so a failed fee transfer
+    ///   never blocks the swap.
+    ///   Mirrors the success semantics of solidity-utils SafeERC20.safeTransferFrom:
+    ///   - the low-level call itself must succeed, AND
+    ///   - either no return data is present and the token is a deployed contract
+    ///     (covers non-standard tokens like USDT that return nothing), OR
+    ///   - at least 32 bytes are returned and decode to boolean `true`.
+    ///   Assembly is used to avoid copying unbounded return data to memory (returndata bomb
+    ///   protection) and to keep gas parity with SafeERC20 on the success path.
+    ///   Note: `maker` and `to` originate from calldata parsing (query struct / bytes20 slice),
+    ///   so their higher bits are already clean and no masking is performed.
+    /// @param token ERC20 token to charge the fee in (tokenIn of the current swap)
+    /// @param maker Address the fee is pulled from
+    /// @param to Fee recipient
+    /// @param amount Fee amount to transfer
+    /// @return success True if the transfer succeeded, false if it failed for any reason
+    function _tryPullFee(address token, address maker, address to, uint256 amount) private returns (bool success) {
+        bytes4 selector = IERC20.transferFrom.selector;
+        assembly ("memory-safe") { // solhint-disable-line no-inline-assembly
+            let data := mload(0x40)
+
+            mstore(data, selector)
+            mstore(add(data, 0x04), maker)
+            mstore(add(data, 0x24), to)
+            mstore(add(data, 0x44), amount)
+            success := call(gas(), token, 0, data, 0x64, 0x0, 0x20)
+            if success {
+                switch returndatasize()
+                case 0 {
+                    success := gt(extcodesize(token), 0)
+                }
+                default {
+                    success := and(gt(returndatasize(), 31), eq(mload(0), 1))
+                }
+            }
+        }
+    }
 
     function _feeAmountIn(Context memory ctx, uint256 feeBps) internal returns (uint256 feeAmountIn) {
         require(ctx.swap.amountIn == 0 || ctx.swap.amountOut == 0, FeeShouldBeAppliedBeforeSwapAmountsComputation());

--- a/src/instructions/Fee.sol
+++ b/src/instructions/Fee.sol
@@ -267,8 +267,8 @@ contract Fee {
     ///   - at least 32 bytes are returned and decode to boolean `true`.
     ///   Assembly is used to avoid copying unbounded return data to memory (returndata bomb
     ///   protection) and to keep gas parity with SafeERC20 on the success path.
-    ///   Note: `maker` and `to` originate from calldata parsing (query struct / bytes20 slice),
-    ///   so their higher bits are already clean and no masking is performed.
+    ///   This function NEVER reverts and never bubbles token errors — any failure maps to `false`.
+    ///   Addresses are defensively masked to 160 bits before being written into calldata.
     /// @param token ERC20 token to charge the fee in (tokenIn of the current swap)
     /// @param maker Address the fee is pulled from
     /// @param to Fee recipient
@@ -276,23 +276,25 @@ contract Fee {
     /// @return success True if the transfer succeeded, false if it failed for any reason
     function _tryPullFee(address token, address maker, address to, uint256 amount) private returns (bool success) {
         bytes4 selector = IERC20.transferFrom.selector;
-        assembly ("memory-safe") { // solhint-disable-line no-inline-assembly
-            let data := mload(0x40)
 
-            mstore(data, selector)
-            mstore(add(data, 0x04), maker)
-            mstore(add(data, 0x24), to)
-            mstore(add(data, 0x44), amount)
-            success := call(gas(), token, 0, data, 0x64, 0x0, 0x20)
-            if success {
-                switch returndatasize()
-                case 0 {
-                    success := gt(extcodesize(token), 0)
-                }
-                default {
-                    success := and(gt(returndatasize(), 31), eq(mload(0), 1))
-                }
+        assembly ("memory-safe") {
+            let fmp := mload(0x40)
+            mstore(0x00, selector)
+            mstore(0x04, and(maker, shr(96, not(0))))
+            mstore(0x24, and(to, shr(96, not(0))))
+            mstore(0x44, amount)
+            success := call(gas(), token, 0, 0x00, 0x64, 0x00, 0x20)
+            // if the call succeeded and returned true, all is good.
+            // otherwise the transfer counts as successful only if:
+            // - the call itself succeeded (no revert), AND
+            // - the returndata is empty (non-standard tokens like USDT), AND
+            // - the token address has code
+            if iszero(and(success, eq(mload(0x00), 1))) {
+                success := and(success, and(iszero(returndatasize()), gt(extcodesize(token), 0)))
             }
+            // restore the free memory pointer and zero slot clobbered by the calldata writes above
+            mstore(0x40, fmp)
+            mstore(0x60, 0)
         }
     }
 

--- a/src/instructions/Fee.sol
+++ b/src/instructions/Fee.sol
@@ -62,11 +62,14 @@ contract Fee {
 
     /// @notice Emitted when a protocol fee transfer fails and the fee is skipped.
     /// @dev Fee charging is best-effort: a failed transfer never blocks the swap.
+    ///   Indexed fields allow off-chain monitors to filter skipped fees by order,
+    ///   token or recipient — monitoring this event is the compensating control
+    ///   for the best-effort charging model.
     /// @param orderHash Unique identifier for the order/strategy
     /// @param token Token in which the fee was to be charged (tokenIn)
     /// @param feeAmount Fee amount that failed to transfer
     /// @param to Intended fee recipient
-    event FeeChargeFailed(bytes32 orderHash, address token, uint256 feeAmount, address to);
+    event FeeChargeFailed(bytes32 indexed orderHash, address indexed token, uint256 feeAmount, address indexed to);
 
     IAqua internal immutable _AQUA;
 
@@ -108,7 +111,7 @@ contract Fee {
         (uint256 feeBps, address to) = FeeArgsBuilder.parseProtocolFee(args);
         uint256 feeAmountIn = _feeAmountIn(ctx, feeBps);
 
-        if (!ctx.vm.isStaticContext && !_tryPullFee(ctx.query.tokenIn, ctx.query.maker, to, feeAmountIn)) {
+        if (!ctx.vm.isStaticContext && feeAmountIn > 0 && !_tryPullFee(ctx.query.tokenIn, ctx.query.maker, to, feeAmountIn)) {
             emit FeeChargeFailed(ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to);
         }
     }
@@ -132,10 +135,12 @@ contract Fee {
         uint256 feeAmountIn = _feeAmountIn(ctx, feeBps);
 
         if (!ctx.vm.isStaticContext) {
-            try _AQUA.pull(ctx.query.maker, ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to) {
-                ctx.swap.amountNetPulled += feeAmountIn;
-            } catch {
-                emit FeeChargeFailed(ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to);
+            if (feeAmountIn > 0) {
+                try _AQUA.pull(ctx.query.maker, ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to) {
+                    ctx.swap.amountNetPulled += feeAmountIn;
+                } catch {
+                    emit FeeChargeFailed(ctx.query.orderHash, ctx.query.tokenIn, feeAmountIn, to);
+                }
             }
         } else {
             ctx.swap.amountNetPulled += feeAmountIn;

--- a/test/DynamicProtocolFee.t.sol
+++ b/test/DynamicProtocolFee.t.sol
@@ -447,4 +447,40 @@ contract DynamicProtocolFeeTest is Test, OpcodesDebug {
         // Lower fee bps should result in lower fee amount
         assertLt(fee2, fee1, "Lower fee bps should result in lower fee amount");
     }
+
+    /// @notice Fee charging is best-effort: if the fee transferFrom fails (no maker
+    ///         allowance for tokenIn), the fee is skipped with FeeChargeFailed and the
+    ///         swap proceeds — the swap itself does not need the maker's tokenIn allowance.
+    function test_DynamicProtocolFee_MakerWithoutAllowance_FeeSkippedAndSwapSucceeds() public {
+        feeProvider.setFeeBpsAndRecipient(0.10e9, protocolFeeRecipient);
+
+        MakerSetup memory setup = MakerSetup({
+            balanceA: 100e18,
+            balanceB: 200e18,
+            dynamicFeeProvider: address(feeProvider),
+            flatInFeeBps: 0,
+            flatOutFeeBps: 0
+        });
+        (ISwapVM.Order memory order, bytes memory signature) = _createOrder(setup);
+
+        // Revoke maker's tokenIn allowance so only the fee transferFrom fails
+        vm.prank(maker);
+        TokenMock(tokenA).approve(address(swapVM), 0);
+
+        bytes memory exactInTakerData = _quotingTakerData(TakerSetup({ isExactIn: true }));
+        bytes memory exactInTakerDataSwap = _swappingTakerData(exactInTakerData, signature);
+
+        bytes32 orderHash = swapVM.hash(order);
+        uint256 amountIn = 10e18;
+
+        // Only the event signature and emitter are asserted (checkData=false):
+        // the exact fee amount depends on the effective exactIn/exactOut mode
+        vm.expectEmit(false, false, false, false, address(swapVM));
+        emit FeeChargeFailed(orderHash, tokenA, 0, protocolFeeRecipient);
+        vm.prank(taker);
+        (, uint256 amountOut,) = swapVM.swap(order, tokenA, tokenB, amountIn, exactInTakerDataSwap);
+
+        assertGt(amountOut, 0, "Swap should succeed with the fee skipped");
+        assertEq(TokenMock(tokenA).balanceOf(protocolFeeRecipient), 0, "Recipient should not receive the skipped fee");
+    }
 }

--- a/test/DynamicProtocolFee.t.sol
+++ b/test/DynamicProtocolFee.t.sol
@@ -473,9 +473,11 @@ contract DynamicProtocolFeeTest is Test, OpcodesDebug {
         bytes32 orderHash = swapVM.hash(order);
         uint256 amountIn = 10e18;
 
-        // Only the event signature and emitter are asserted (checkData=false):
-        // the exact fee amount depends on the effective exactIn/exactOut mode
-        vm.expectEmit(false, false, false, false, address(swapVM));
+        // _swappingTakerData drops the isExactIn flag (pre-existing quirk), so the swap
+        // effectively runs in exactOut mode and the fee amount depends on the AMM-quoted
+        // amountIn. The indexed fields (orderHash, token, recipient) and the emitter are
+        // asserted; the recipient balance check below proves no fee was transferred.
+        vm.expectEmit(true, true, true, false, address(swapVM));
         emit FeeChargeFailed(orderHash, tokenA, 0, protocolFeeRecipient);
         vm.prank(taker);
         (, uint256 amountOut,) = swapVM.swap(order, tokenA, tokenB, amountIn, exactInTakerDataSwap);

--- a/test/ProtocolFee.t.sol
+++ b/test/ProtocolFee.t.sol
@@ -447,9 +447,11 @@ contract ProtocolFeeTest is Test, OpcodesDebug {
         bytes32 orderHash = swapVM.hash(order);
         uint256 amountIn = 10e18;
 
-        // Only the event signature and emitter are asserted (checkData=false):
-        // the exact fee amount depends on the effective exactIn/exactOut mode
-        vm.expectEmit(false, false, false, false, address(swapVM));
+        // _swappingTakerData drops the isExactIn flag (pre-existing quirk), so the swap
+        // effectively runs in exactOut mode and the fee amount depends on the AMM-quoted
+        // amountIn. The indexed fields (orderHash, token, recipient) and the emitter are
+        // asserted; the recipient balance check below proves no fee was transferred.
+        vm.expectEmit(true, true, true, false, address(swapVM));
         emit FeeChargeFailed(orderHash, tokenA, 0, protocolFeeRecipient);
         vm.prank(taker);
         (, uint256 amountOut,) = swapVM.swap(order, tokenA, tokenB, amountIn, exactInTakerDataSwap);

--- a/test/ProtocolFee.t.sol
+++ b/test/ProtocolFee.t.sol
@@ -423,4 +423,38 @@ contract ProtocolFeeTest is Test, OpcodesDebug {
         uint256 noFeeAmountOut = setup.balanceB * amountIn / (setup.balanceA + amountIn);
         assertLt(amountOut, noFeeAmountOut, "AmountOut should be less with both fees applied");
     }
+
+    /// @notice Fee charging is best-effort: if the fee transferFrom fails (no maker
+    ///         allowance for tokenIn), the fee is skipped with FeeChargeFailed and the
+    ///         swap proceeds — the swap itself does not need the maker's tokenIn allowance.
+    function test_ProtocolFeeAmountIn_MakerWithoutAllowance_FeeSkippedAndSwapSucceeds() public {
+        MakerSetup memory setup = MakerSetup({
+            balanceA: 100e18,
+            balanceB: 200e18,
+            protocolFeeBps: 0.10e9, // 10% fee
+            flatInFeeBps: 0,
+            flatOutFeeBps: 0
+        });
+        (ISwapVM.Order memory order, bytes memory signature) = _createOrderWithFeeType(setup, true);
+
+        // Revoke maker's tokenIn allowance so only the fee transferFrom fails
+        vm.prank(maker);
+        TokenMock(tokenA).approve(address(swapVM), 0);
+
+        bytes memory exactInTakerData = _quotingTakerData(TakerSetup({ isExactIn: true }));
+        bytes memory exactInTakerDataSwap = _swappingTakerData(exactInTakerData, signature);
+
+        bytes32 orderHash = swapVM.hash(order);
+        uint256 amountIn = 10e18;
+
+        // Only the event signature and emitter are asserted (checkData=false):
+        // the exact fee amount depends on the effective exactIn/exactOut mode
+        vm.expectEmit(false, false, false, false, address(swapVM));
+        emit FeeChargeFailed(orderHash, tokenA, 0, protocolFeeRecipient);
+        vm.prank(taker);
+        (, uint256 amountOut,) = swapVM.swap(order, tokenA, tokenB, amountIn, exactInTakerDataSwap);
+
+        assertGt(amountOut, 0, "Swap should succeed with the fee skipped");
+        assertEq(TokenMock(tokenA).balanceOf(protocolFeeRecipient), 0, "Recipient should not receive the skipped fee");
+    }
 }

--- a/test/ProtocolFeeAqua.t.sol
+++ b/test/ProtocolFeeAqua.t.sol
@@ -4,13 +4,24 @@ pragma solidity 0.8.30;
 /// @custom:license-url https://github.com/1inch/swap-vm/blob/main/LICENSES/SwapVM-1.1.txt
 /// @custom:copyright © 2025 Degensoft Ltd
 
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
 import { AquaSwapVMTest } from "./base/AquaSwapVMTest.sol";
 
 import { ISwapVM } from "../src/interfaces/ISwapVM.sol";
-import { BPS } from "../src/instructions/Fee.sol";
+import { Fee, FeeArgsBuilder, BPS } from "../src/instructions/Fee.sol";
+import { XYCConcentrate, XYCConcentrateArgsBuilder } from "../src/instructions/XYCConcentrate.sol";
+import { XYCSwap } from "../src/instructions/XYCSwap.sol";
+import { Controls } from "../src/instructions/Controls.sol";
 import { ContextLib } from "../src/libs/VM.sol";
 
+import { ProtocolFeeProviderMock } from "../mocks/ProtocolFeeProviderMock.sol";
+
+import { Program, ProgramBuilder } from "./utils/ProgramBuilder.sol";
+
 contract ProtocolFeeAquaTest is AquaSwapVMTest {
+    using ProgramBuilder for Program;
+
     function setUp() public virtual override {
         super.setUp();
     }
@@ -324,13 +335,122 @@ contract ProtocolFeeAquaTest is AquaSwapVMTest {
 
         _drainTokenBToRangeBoundaryViaSwap(order, strategyHash);
 
+        // Recipient already collected fees in tokenA during the drain — snapshot here
+        (uint256 recipientBalanceABefore, uint256 recipientBalanceBBefore) = getProtocolRecipientBalances();
+
         // Swap back: tokenB (drained) -> tokenA, exactOut
         SwapProgram memory backSwap = _swapProgram(10e18, false, false);
         mintTokenInToTaker(backSwap, 1_000_000e18);
+
+        // exactOut: the fee amount depends on the AMM-quoted amountIn, so only the
+        // indexed fields (orderHash, token, recipient) and the emitter are asserted
+        vm.expectEmit(true, true, true, false, address(swapVM));
+        emit FeeChargeFailed(swapVM.hash(order), address(tokenB), 0, protocolFeeRecipient);
 
         (uint256 amountIn, uint256 amountOut) = swap(backSwap, order);
 
         assertEq(amountOut, backSwap.amount, "Swap back should produce the exact amountOut");
         assertGt(amountIn, 0, "Swap back should consume non-zero amountIn");
+
+        // Fee was skipped: recipient got nothing, the full amountIn stayed in the strategy
+        (uint256 recipientBalanceAAfter, uint256 recipientBalanceBAfter) = getProtocolRecipientBalances();
+        assertEq(recipientBalanceAAfter, recipientBalanceABefore, "Recipient balance A should not change");
+        assertEq(recipientBalanceBAfter, recipientBalanceBBefore, "Recipient should not receive the skipped fee");
+        (, uint256 aquaBalanceBAfter) = getAquaBalances(strategyHash);
+        assertEq(aquaBalanceBAfter, amountIn, "Full amountIn incl. fee share should stay in the strategy");
+    }
+
+    // ========== Aqua Dynamic Protocol Fee Tests ==========
+
+    /// @dev Program for `_aquaDynamicProtocolFeeAmountInXD`: plain XYC swap over Aqua
+    ///      balances with a dynamic (provider-driven) protocol fee on amountIn.
+    function _xycDynamicFeeProgram(address feeProvider) internal view returns (bytes memory) {
+        Program memory p = ProgramBuilder.init(_opcodes());
+        return bytes.concat(
+            p.build(Fee._aquaDynamicProtocolFeeAmountInXD, FeeArgsBuilder.buildDynamicProtocolFee(feeProvider)),
+            p.build(XYCSwap._xycSwapXD),
+            p.build(Controls._salt, abi.encodePacked(vm.randomUint()))
+        );
+    }
+
+    /// @dev Same as _xycDynamicFeeProgram but with concentrated liquidity, mirroring
+    ///      _concentrateMakerSetup: price range [0.25, 4] symmetric around spot 1.
+    function _concentrateDynamicFeeProgram(address feeProvider) internal view returns (bytes memory) {
+        Program memory p = ProgramBuilder.init(_opcodes());
+        uint256 sqrtPmin = Math.sqrt(0.25e18 * 1e18);
+        uint256 sqrtPmax = Math.sqrt(4e18 * 1e18);
+        return bytes.concat(
+            p.build(Fee._aquaDynamicProtocolFeeAmountInXD, FeeArgsBuilder.buildDynamicProtocolFee(feeProvider)),
+            p.build(XYCConcentrate._xycConcentrateGrowLiquidity2D, XYCConcentrateArgsBuilder.build2D(sqrtPmin, sqrtPmax)),
+            p.build(XYCSwap._xycSwapXD),
+            p.build(Controls._salt, abi.encodePacked(vm.randomUint()))
+        );
+    }
+
+    /// @notice Success path: the dynamic Aqua protocol fee is pulled from the maker's
+    ///         strategy balance to the provider-defined recipient.
+    function test_Aqua_DynamicProtocolFee_ExactIn_ReceivedByRecipient() public {
+        ProtocolFeeProviderMock feeProvider = new ProtocolFeeProviderMock(0.10e9, protocolFeeRecipient, address(this));
+        ISwapVM.Order memory order = createStrategy(_xycDynamicFeeProgram(address(feeProvider)));
+        bytes32 strategyHash = shipStrategy(order, tokenA, tokenB, INITIAL_BALANCE_A, INITIAL_BALANCE_B);
+        SwapProgram memory swapProgram = _swapProgram(100e18, true, true); // Swap 100 tokenA for tokenB
+
+        (uint256 makerBalanceABefore,) = getAquaBalances(strategyHash);
+
+        mintTokenInToTaker(swapProgram);
+        mintTokenInToMaker(swapProgram, 200e18);
+        mintTokenOutToMaker(swapProgram, 200e18);
+        (uint256 recipientBalanceABefore,) = getProtocolRecipientBalances();
+
+        (uint256 amountIn, uint256 amountOut) = swap(swapProgram, order);
+
+        // exactIn: fee is computed on the taker-defined amountIn
+        uint256 expectedFee = amountIn * 0.10e9 / BPS;
+        (uint256 recipientBalanceAAfter,) = getProtocolRecipientBalances();
+        (uint256 makerBalanceAAfter,) = getAquaBalances(strategyHash);
+
+        assertGt(amountOut, 0, "Swap should produce non-zero amountOut");
+        assertEq(recipientBalanceAAfter - recipientBalanceABefore, expectedFee, "Recipient should receive the dynamic protocol fee in tokenIn");
+        assertEq(makerBalanceAAfter, makerBalanceABefore + amountIn - expectedFee, "Maker balance A should increase by amountIn minus protocol fee");
+    }
+
+    /// @notice Catch path: at the range boundary the dynamic Aqua fee pull in drained
+    ///         tokenIn fails, the fee is skipped with FeeChargeFailed and the swap
+    ///         proceeds — mirroring the static-fee boundary test.
+    function test_Aqua_DynamicProtocolFee_Concentrate_SwapBackAtRangeBoundary_FeeSkipped() public {
+        uint32 feeBps = 0.01e9; // 1% protocol fee
+        ProtocolFeeProviderMock feeProvider = new ProtocolFeeProviderMock(feeBps, protocolFeeRecipient, address(this));
+        ISwapVM.Order memory order = createStrategy(_concentrateDynamicFeeProgram(address(feeProvider)));
+        bytes32 strategyHash = shipStrategy(order, tokenA, tokenB, 1000e18, 1000e18);
+
+        _drainTokenBToRangeBoundary(order, strategyHash);
+
+        // Recipient already collected fees in tokenA during the drain — snapshot here
+        (uint256 recipientBalanceABefore, uint256 recipientBalanceBBefore) = getProtocolRecipientBalances();
+
+        // Swap back: tokenB (drained) -> tokenA
+        SwapProgram memory backSwap = _swapProgram(10e18, false, true);
+        mintTokenInToTaker(backSwap);
+
+        // Quote agrees the swap back is possible (static context skips the fee pull)
+        (, uint256 quotedAmountOut) = quote(backSwap, order);
+        assertGt(quotedAmountOut, 0, "Quote for swap back should succeed");
+
+        uint256 expectedFee = backSwap.amount * feeBps / BPS;
+        vm.expectEmit(address(swapVM));
+        emit FeeChargeFailed(swapVM.hash(order), address(tokenB), expectedFee, protocolFeeRecipient);
+
+        (uint256 amountIn, uint256 amountOut) = swap(backSwap, order);
+
+        assertEq(amountIn, backSwap.amount, "Swap back should consume the exact amountIn");
+        assertGt(amountOut, 0, "Swap back should produce non-zero amountOut");
+        assertEq(amountOut, quotedAmountOut, "Swap should match quote (quote/swap parity)");
+
+        // Fee was skipped: recipient got nothing, the full amountIn stayed in the strategy
+        (uint256 recipientBalanceAAfter, uint256 recipientBalanceBAfter) = getProtocolRecipientBalances();
+        assertEq(recipientBalanceAAfter, recipientBalanceABefore, "Recipient balance A should not change");
+        assertEq(recipientBalanceBAfter, recipientBalanceBBefore, "Recipient should not receive the skipped fee");
+        (, uint256 aquaBalanceBAfter) = getAquaBalances(strategyHash);
+        assertEq(aquaBalanceBAfter, amountIn, "Full amountIn incl. fee share should stay in the strategy");
     }
 }

--- a/test/ProtocolFeeAqua.t.sol
+++ b/test/ProtocolFeeAqua.t.sol
@@ -189,4 +189,148 @@ contract ProtocolFeeAquaTest is AquaSwapVMTest {
         assertApproxEqAbs(amountIn, amountIn2, 2, "AmountIn should be consistent between exactIn and exactOut swaps");
         assertApproxEqAbs(amountOut, amountOut2, 2, "AmountOut should be consistent between exactIn and exactOut swaps");
     }
+
+    /// @dev Concentrated pool with equal balances: P_spot = 1 regardless of tokenA/tokenB
+    ///      address ordering, price range [0.25, 4] is symmetric around the spot.
+    function _concentrateMakerSetup(uint32 protocolFeeBps) internal view returns (MakerSetup memory) {
+        return MakerSetup({
+            balanceA: 1000e18,
+            balanceB: 1000e18,
+            priceMin: 0.25e18,
+            priceMax: 4e18,
+            protocolFeeBps: protocolFeeBps,
+            feeInBps: 0,
+            protocolFeeRecipient: protocolFeeRecipient,
+            swapType: SwapType.CONCENTRATE_GROW_LIQUIDITY
+        });
+    }
+
+    /// @dev Drives the pool to the range boundary by buying the entire tokenB balance,
+    ///      leaving the strategy's Aqua accounting balance of tokenB at exactly zero.
+    function _drainTokenBToRangeBoundary(ISwapVM.Order memory order, bytes32 strategyHash) internal {
+        // Maker wallet holds plenty of both tokens, so wallet funds are never the
+        // constraint — only the strategy's Aqua accounting balance matters below.
+        tokenA.mint(maker, 1_000_000e18);
+        tokenB.mint(maker, 1_000_000e18);
+
+        tradeToZeroBalance(order, tokenB);
+
+        (, uint256 aquaBalanceB) = getAquaBalances(strategyHash);
+        assertEq(aquaBalanceB, 0, "tokenB should be fully drained to the range boundary");
+    }
+
+    /// @notice Control: without protocol fee the AMM math allows swapping back
+    ///         from the range boundary (virtual reserves cover the zero real balance).
+    function test_Aqua_Concentrate_SwapBackAtRangeBoundary_NoProtocolFee_Succeeds() public {
+        MakerSetup memory setup = _concentrateMakerSetup(0);
+        ISwapVM.Order memory order = createStrategy(setup);
+        bytes32 strategyHash = shipStrategy(order, tokenA, tokenB, setup.balanceA, setup.balanceB);
+
+        _drainTokenBToRangeBoundary(order, strategyHash);
+
+        // Swap back: tokenB (drained) -> tokenA
+        SwapProgram memory backSwap = _swapProgram(10e18, false, true);
+        mintTokenInToTaker(backSwap);
+
+        (uint256 amountIn, uint256 amountOut) = swap(backSwap, order);
+
+        assertEq(amountIn, backSwap.amount, "Swap back should consume the exact amountIn");
+        assertGt(amountOut, 0, "Swap back should produce non-zero amountOut");
+    }
+
+    /// @notice With Aqua protocol fee the swap back from the range boundary succeeds:
+    ///         fee charging is best-effort. The fee pull in tokenIn fails (the strategy's
+    ///         tokenIn balance is drained to zero, and the pull happens before the taker
+    ///         pushes tokenIn), so the fee is skipped with a FeeChargeFailed event and
+    ///         the fee share remains in the maker's strategy balance.
+    function test_Aqua_ProtocolFee_Concentrate_SwapBackAtRangeBoundary_Succeeds() public {
+        MakerSetup memory setup = _concentrateMakerSetup(0.01e9); // 1% protocol fee
+        ISwapVM.Order memory order = createStrategy(setup);
+        bytes32 strategyHash = shipStrategy(order, tokenA, tokenB, setup.balanceA, setup.balanceB);
+
+        _drainTokenBToRangeBoundary(order, strategyHash);
+
+        // Recipient already collected fees in tokenA during the drain — snapshot here
+        (uint256 recipientBalanceABefore, uint256 recipientBalanceBBefore) = getProtocolRecipientBalances();
+
+        // Swap back: tokenB (drained) -> tokenA
+        SwapProgram memory backSwap = _swapProgram(10e18, false, true);
+        mintTokenInToTaker(backSwap);
+
+        // Quote agrees the swap back is possible (static context skips the fee pull)
+        (, uint256 quotedAmountOut) = quote(backSwap, order);
+        assertGt(quotedAmountOut, 0, "Quote for swap back should succeed");
+
+        uint256 expectedFee = backSwap.amount * setup.protocolFeeBps / BPS;
+        vm.expectEmit(address(swapVM));
+        emit FeeChargeFailed(swapVM.hash(order), address(tokenB), expectedFee, protocolFeeRecipient);
+
+        (uint256 amountIn, uint256 amountOut) = swap(backSwap, order);
+
+        assertEq(amountIn, backSwap.amount, "Swap back should consume the exact amountIn");
+        assertGt(amountOut, 0, "Swap back should produce non-zero amountOut");
+        assertEq(amountOut, quotedAmountOut, "Swap should match quote (quote/swap parity)");
+
+        // Fee was skipped: recipient got nothing, the full amountIn stayed in the strategy
+        (uint256 recipientBalanceAAfter, uint256 recipientBalanceBAfter) = getProtocolRecipientBalances();
+        assertEq(recipientBalanceAAfter, recipientBalanceABefore, "Recipient balance A should not change");
+        assertEq(recipientBalanceBAfter, recipientBalanceBBefore, "Recipient should not receive the skipped fee");
+        (, uint256 aquaBalanceBAfter) = getAquaBalances(strategyHash);
+        assertEq(aquaBalanceBAfter, amountIn, "Full amountIn incl. fee share should stay in the strategy");
+    }
+
+    /// @dev Same as _drainTokenBToRangeBoundary, but drains with a real swap only —
+    ///      no quote() involved: the taker is simply funded generously upfront.
+    function _drainTokenBToRangeBoundaryViaSwap(ISwapVM.Order memory order, bytes32 strategyHash) internal {
+        // Maker wallet holds plenty of both tokens, so wallet funds are never the
+        // constraint — only the strategy's Aqua accounting balance matters below.
+        tokenA.mint(maker, 1_000_000e18);
+        tokenB.mint(maker, 1_000_000e18);
+
+        (, uint256 aquaBalanceB) = getAquaBalances(strategyHash);
+        SwapProgram memory drainSwap = _swapProgram(aquaBalanceB, true, false); // tokenA -> tokenB, exactOut full balance
+        mintTokenInToTaker(drainSwap, 1_000_000e18);
+        swap(drainSwap, order);
+
+        (, uint256 aquaBalanceBAfter) = getAquaBalances(strategyHash);
+        assertEq(aquaBalanceBAfter, 0, "tokenB should be fully drained to the range boundary");
+    }
+
+    /// @notice Control (swap-only, exactOut): without protocol fee the swap back from
+    ///         the range boundary succeeds. No quote() is used anywhere in this test.
+    function test_Aqua_Concentrate_SwapBackAtRangeBoundary_NoProtocolFee_ExactOut_Succeeds() public {
+        MakerSetup memory setup = _concentrateMakerSetup(0);
+        ISwapVM.Order memory order = createStrategy(setup);
+        bytes32 strategyHash = shipStrategy(order, tokenA, tokenB, setup.balanceA, setup.balanceB);
+
+        _drainTokenBToRangeBoundaryViaSwap(order, strategyHash);
+
+        // Swap back: tokenB (drained) -> tokenA, exactOut
+        SwapProgram memory backSwap = _swapProgram(10e18, false, false);
+        mintTokenInToTaker(backSwap, 1_000_000e18);
+
+        (uint256 amountIn, uint256 amountOut) = swap(backSwap, order);
+
+        assertEq(amountOut, backSwap.amount, "Swap back should produce the exact amountOut");
+        assertGt(amountIn, 0, "Swap back should consume non-zero amountIn");
+    }
+
+    /// @notice Same as above in exactOut mode (swap-only, no quote() anywhere): the fee
+    ///         pull in drained tokenIn fails, the fee is skipped and the swap succeeds.
+    function test_Aqua_ProtocolFee_Concentrate_SwapBackAtRangeBoundary_ExactOut_Succeeds() public {
+        MakerSetup memory setup = _concentrateMakerSetup(0.01e9); // 1% protocol fee
+        ISwapVM.Order memory order = createStrategy(setup);
+        bytes32 strategyHash = shipStrategy(order, tokenA, tokenB, setup.balanceA, setup.balanceB);
+
+        _drainTokenBToRangeBoundaryViaSwap(order, strategyHash);
+
+        // Swap back: tokenB (drained) -> tokenA, exactOut
+        SwapProgram memory backSwap = _swapProgram(10e18, false, false);
+        mintTokenInToTaker(backSwap, 1_000_000e18);
+
+        (uint256 amountIn, uint256 amountOut) = swap(backSwap, order);
+
+        assertEq(amountOut, backSwap.amount, "Swap back should produce the exact amountOut");
+        assertGt(amountIn, 0, "Swap back should consume non-zero amountIn");
+    }
 }


### PR DESCRIPTION
## Summary

Protocol fee instructions (`_protocolFeeAmountInXD`, `_aquaProtocolFeeAmountInXD` and their dynamic variants) pull the fee in `tokenIn` from the maker *before* the taker's tokens arrive. On a concentrated AMM (`XYCConcentrate`) driven to a range boundary the strategy holds zero `tokenIn`, so `Aqua.pull` underflowed (panic 0x11) and the swap-back was permanently blocked — while `quote` reported the swap as fine.

**Fix — fee charging is now best-effort and never blocks the swap:**

- Aqua fee pulls are wrapped in `try/catch`;
- direct ERC20 fee pulls go through a new non-reverting `_tryPullFee` helper (mirrors `SafeERC20.safeTransferFrom` success semantics, incl. tokens without return data);
- on failure the fee is skipped and `FeeChargeFailed(orderHash, token, feeAmount, to)` is emitted, with `orderHash`, `token` and `to` indexed for cheap off-chain filtering;
- `ctx.swap.amountNetPulled` is incremented **only on successful** Aqua pulls, keeping the `AquaBalanceInsufficientAfterTakerPush` taker-payment check strict when the fee was skipped;
- zero fee amounts skip the transfer entirely (`feeAmountIn > 0` guard in all four variants), avoiding spurious failure events on zero-transfer-reverting tokens.

## Design decision: fee enforcement is best-effort (accepted risk)

The guiding requirement is that **a failed fee must never block a swap**. This deliberately weakens on-chain fee enforcement, with the following accepted consequences:

- The presence of a protocol-fee opcode in an order's program **no longer guarantees the fee is actually paid**.
- A maker can deliberately make fee pulls fail and trade fee-free — e.g. for direct ERC20 fees, keep the `tokenIn` allowance at zero (the swap itself never needs the maker's `tokenIn` allowance); for Aqua fees, starve the wallet balance/allowance backing `Aqua.pull`.
- Swap pricing already includes the fee, so a skipped fee **accrues to the maker** (for Aqua orders it remains in the strategy balance); the taker pays the same amount either way. At a range boundary an Aqua strategy effectively trades fee-free in the drained direction until rebalanced.

**Compensating control:** every skipped fee emits `FeeChargeFailed` with indexed `orderHash`, `token` and `to`. Integrators that rely on protocol fees must monitor this event off-chain and delist/penalize makers that systematically dodge fees.

**Out of scope:** `FeeExperimental` amountOut-side fee variants intentionally keep the old hard-reverting behavior.

## Test plan

- [x] `test_Aqua_ProtocolFee_Concentrate_SwapBackAtRangeBoundary_Succeeds` — exactIn swap-back at the boundary succeeds, `FeeChargeFailed` asserted with exact params, recipient gets nothing, strategy keeps the full amountIn, quote/swap parity (was reverting before the fix)
- [x] `test_Aqua_ProtocolFee_Concentrate_SwapBackAtRangeBoundary_ExactOut_Succeeds` — same for exactOut, incl. event (indexed fields) and recipient/strategy balance assertions
- [x] `test_Aqua_DynamicProtocolFee_ExactIn_ReceivedByRecipient` — dynamic Aqua fee success path: fee pulled to the provider-defined recipient, strategy balance accounted
- [x] `test_Aqua_DynamicProtocolFee_Concentrate_SwapBackAtRangeBoundary_FeeSkipped` — dynamic Aqua fee catch path at the range boundary (first coverage of `_aquaDynamicProtocolFeeAmountInXD`)
- [x] `test_ProtocolFeeAmountIn_MakerWithoutAllowance_FeeSkippedAndSwapSucceeds` — ERC20 variant: fee skipped when the maker allowance is revoked, swap succeeds
- [x] `test_DynamicProtocolFee_MakerWithoutAllowance_FeeSkippedAndSwapSucceeds` — dynamic ERC20 variant
- [x] Full `forge test` suite passes (720 tests)