### PR TITLE
relax pragmy solidity

### DIFF
--- a/src/libs/MakerTraits.sol
+++ b/src/libs/MakerTraits.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LicenseRef-Degensoft-SwapVM-1.1
-pragma solidity 0.8.30;
+pragma solidity ^0.8.30;
 
 /// @custom:license-url https://github.com/1inch/swap-vm/blob/main/LICENSES/SwapVM-1.1.txt
 /// @custom:copyright © 2025 Degensoft Ltd


### PR DESCRIPTION
## Change Summary
**What does this PR change?**
MakerTraits are imported by interfaces making the interfaces incompatible with versions above 8.30

This pr adapts to at least allow versions above.

## Risk Assessment
**Risk Level:**
- [x] **Low** - Minor changes, no operational impact


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single pragma line change with no contract logic or behavior changes; only affects compile-time version matching for dependents.
> 
> **Overview**
> Updates **`MakerTraits.sol`** from a pinned `pragma solidity 0.8.30` to **`^0.8.30`** so the `MakerTraits` type can be imported when compiling with Solidity **0.8.30 or newer**.
> 
> This matters because **`ISwapVM`** (and other interfaces) import `MakerTraits`; a strict `0.8.30` pragma on the library previously blocked integrators on **>0.8.30** even when their interfaces used a flexible pragma. **No runtime or ABI logic changes**—compiler compatibility only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93142c1f684f656c3b8519978b1d18ce529db3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->