### PR TITLE
fix: make ISwapVM usable on solc ^0.8.0 as intended

### DIFF
--- a/src/interfaces/ISwapVM.sol
+++ b/src/interfaces/ISwapVM.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 /// @custom:license-url https://github.com/1inch/swap-vm/blob/main/LICENSES/SwapVM-1.1.txt
 /// @custom:copyright © 2025 Degensoft Ltd
 
-import { MakerTraits } from "../libs/MakerTraits.sol";
+type MakerTraits is uint256;
 
 /// @title ISwapVM
 /// @notice Core interface for SwapVM - executes programmable token swap strategies

--- a/src/libs/MakerTraits.sol
+++ b/src/libs/MakerTraits.sol
@@ -9,9 +9,7 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { Calldata } from "@1inch/solidity-utils/contracts/libraries/Calldata.sol";
 import { InstructionArgs } from "./InstructionArgs.sol";
 import { IMakerHooks } from "../interfaces/IMakerHooks.sol";
-import { ISwapVM } from "../interfaces/ISwapVM.sol";
-
-type MakerTraits is uint256;
+import { ISwapVM, MakerTraits } from "../interfaces/ISwapVM.sol";
 
 library MakerTraitsLib {
     using MakerTraitsLib for MakerTraits;


### PR DESCRIPTION
by moving `type MakerTraits` from `MakerTraits` to `ISwapVM` we:
- remove a circular dependency
- make ISwapVM dependency-less so it's better integratable in external projects (currently the interface is not usable on projects that are built against a solc version different to 8.30)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small import/type relocation with no runtime logic changes; integrators may need to import `MakerTraits` from `ISwapVM` if they referenced it only via `MakerTraits.sol`.
> 
> **Overview**
> **`type MakerTraits`** is now declared in `ISwapVM.sol` instead of `MakerTraits.sol`, and `ISwapVM` no longer imports the maker traits library (it previously pulled it in only for that type).
> 
> `MakerTraits.sol` drops its local type alias and imports **`MakerTraits`** from `ISwapVM` alongside `ISwapVM`, which removes the circular dependency between the interface and the library. Integrators can depend on **`ISwapVM`** alone under **`pragma solidity ^0.8.0`** without inheriting the library’s **`0.8.30`** pin or its heavier import graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9dbce9f096603069f9735e6a2da3cac3e0e51af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->