### PR TITLE
OraclePriceAdjuster: scale the oracle answer to the pair's token decimals

### DIFF
--- a/contracts/instructions/OraclePriceAdjuster.sol
+++ b/contracts/instructions/OraclePriceAdjuster.sol
@@ -15,9 +15,13 @@ import { InstructionArgs } from "../libs/InstructionArgs.sol";
 import { IPriceOracle } from "./interfaces/IPriceOracle.sol";
 
 /// @notice OraclePriceAdjuster opcode, price adjustment towards a Chainlink oracle price with price percent cap
-/// @dev Encoding: [uint64 maxPriceDecay, uint16 maxStaleness, uint8 oracleDecimals, address oracleAddress]
+/// @dev Encoding: [uint64 maxPriceDecay, uint16 maxStaleness, uint8 oracleDecimals, uint8 tokenInDecimals, uint8 tokenOutDecimals, address oracleAddress]
 ///   maxStaleness = 0 skips the staleness check, oracleDecimals = 0 fetches decimals from the oracle
 /// @dev Supports only single direction swaps, adjustment is applied only if favorable for the taker
+/// @dev tokenInDecimals and tokenOutDecimals describe the swap direction the instruction runs on.
+///   The swap price is computed from raw token amounts, so the oracle answer is scaled to
+///   10 ** (18 + tokenOutDecimals - tokenInDecimals) rather than to 1e18. On a pair where both
+///   tokens have 18 decimals that exponent is 18 and the two are the same thing.
 library OraclePriceAdjuster {
     using InstructionArgs for bytes;
     using InstructionBuilder for MemoryPtr;
@@ -33,39 +37,80 @@ library OraclePriceAdjuster {
     uint256 constant ONE = 1e18;
     uint8 constant DECIMALS = 18;
 
-    function sizeOf(uint64, uint16, uint8, address) internal pure returns (uint256) {
-        return InstructionBuilder.sizeOf() + 8 + 2 + 1 + 20;
+    function sizeOf(uint64, uint16, uint8, uint8, uint8, address) internal pure returns (uint256) {
+        return InstructionBuilder.sizeOf() + 8 + 2 + 1 + 1 + 1 + 20;
     }
 
     function build(
         uint64 maxPriceDecay,
         uint16 maxStaleness,
         uint8 oracleDecimals,
+        uint8 tokenInDecimals,
+        uint8 tokenOutDecimals,
         address oracleAddress
     ) internal pure returns (bytes memory) {
         return build(
-            MemoryPtrLib.alloc(sizeOf(maxPriceDecay, maxStaleness, oracleDecimals, oracleAddress)),
-            maxPriceDecay, maxStaleness, oracleDecimals, oracleAddress
+            MemoryPtrLib.alloc(sizeOf(maxPriceDecay, maxStaleness, oracleDecimals, tokenInDecimals, tokenOutDecimals, oracleAddress)),
+            maxPriceDecay, maxStaleness, oracleDecimals, tokenInDecimals, tokenOutDecimals, oracleAddress
         ).resolve();
     }
 
-    function build(MemoryPtr ptrStart, uint64 maxPriceDecay, uint16 maxStaleness, uint8 oracleDecimals, address oracleAddress) internal pure returns (MemoryPtr ptr) {
+    function build(
+        MemoryPtr ptrStart,
+        uint64 maxPriceDecay,
+        uint16 maxStaleness,
+        uint8 oracleDecimals,
+        uint8 tokenInDecimals,
+        uint8 tokenOutDecimals,
+        address oracleAddress
+    ) internal pure returns (MemoryPtr ptr) {
         require(maxPriceDecay < ONE, OraclePriceAdjusterWrongMaxPriceDecay(maxPriceDecay));
 
         ptr = ptrStart.pushHeader(opcode);
-        ptr = ptr.push(maxPriceDecay, 8).push(maxStaleness, 2).push(oracleDecimals).push(oracleAddress);
+        ptr = ptr.push(maxPriceDecay, 8).push(maxStaleness, 2).push(oracleDecimals).push(tokenInDecimals).push(tokenOutDecimals).push(oracleAddress);
         ptrStart.patchLength(ptr);
     }
 
-    function parse(bytes calldata args) internal pure returns (uint64 maxPriceDecay, uint16 maxStaleness, uint8 oracleDecimals, address oracleAddress) {
+    function parse(bytes calldata args) internal pure returns (
+        uint64 maxPriceDecay,
+        uint16 maxStaleness,
+        uint8 oracleDecimals,
+        uint8 tokenInDecimals,
+        uint8 tokenOutDecimals,
+        address oracleAddress
+    ) {
         maxPriceDecay = args.at(0).asU64();
         maxStaleness = args.at(8).asU16();
         oracleDecimals = args.at(10).asU8();
-        oracleAddress = args.at(11).asAddress();
+        tokenInDecimals = args.at(11).asU8();
+        tokenOutDecimals = args.at(12).asU8();
+        oracleAddress = args.at(13).asAddress();
+    }
+
+    /// @notice Scales an oracle answer to the units the swap price is computed in
+    /// @dev A single net exponent, so the answer's low digits survive a scale-down
+    function scaleAnswer(
+        uint256 answer,
+        uint8 oracleDecimals,
+        uint8 tokenInDecimals,
+        uint8 tokenOutDecimals
+    ) internal pure returns (uint256) {
+        uint256 numerator = uint256(DECIMALS) + tokenOutDecimals;
+        uint256 denominator = uint256(oracleDecimals) + tokenInDecimals;
+
+        if (numerator >= denominator) return answer * 10 ** (numerator - denominator);
+        return answer / 10 ** (denominator - numerator);
     }
 
     function exec(Context memory ctx, bytes calldata args) internal view {
-        (uint64 maxPriceDecay, uint16 maxStaleness, uint8 oracleDecimals, address oracleAddress) = parse(args);
+        (
+            uint64 maxPriceDecay,
+            uint16 maxStaleness,
+            uint8 oracleDecimals,
+            uint8 tokenInDecimals,
+            uint8 tokenOutDecimals,
+            address oracleAddress
+        ) = parse(args);
 
         // Get latest price data from Chainlink
         IPriceOracle oracle = IPriceOracle(oracleAddress);
@@ -80,13 +125,9 @@ library OraclePriceAdjuster {
             oracleDecimals = oracle.decimals();
         }
 
-        // Convert oracle price to 1e18 scale using provided decimals
-        uint256 oraclePrice = answer.toUint256();
-        if (oracleDecimals < DECIMALS) {
-            oraclePrice = oraclePrice * 10 ** (DECIMALS - oracleDecimals);
-        } else if (oracleDecimals > DECIMALS) {
-            oraclePrice = oraclePrice / 10 ** (oracleDecimals - DECIMALS);
-        }
+        // Convert oracle price to the scale currentPrice below is computed in, which is 1e18 only
+        // when both tokens have 18 decimals
+        uint256 oraclePrice = scaleAnswer(answer.toUint256(), oracleDecimals, tokenInDecimals, tokenOutDecimals);
 
         // Calculate current swap price (tokenOut per tokenIn)
         // Price = amountOut / amountIn

--- a/test/solidity/OraclePriceAdjuster.t.sol
+++ b/test/solidity/OraclePriceAdjuster.t.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: LicenseRef-Degensoft-SwapVM-1.1
+pragma solidity ^0.8.27;
+
+/// @custom:license-url https://github.com/1inch/swap-vm/blob/main/LICENSES/SwapVM-1.1.txt
+/// @custom:copyright © 2026 Degensoft Ltd
+
+import { Test } from "forge-std/Test.sol";
+import { TokenMock } from "@1inch/solidity-utils/contracts/mocks/TokenMock.sol";
+
+import { Aqua } from "@1inch/aqua/src/Aqua.sol";
+
+import { ISwapVM } from "../../contracts/interfaces/ISwapVM.sol";
+import { SwapVMRouter } from "../../contracts/routers/SwapVMRouter.sol";
+import { MakerTraitsLib } from "../../contracts/libs/MakerTraits.sol";
+import { TakerTraitsLib } from "../../contracts/libs/TakerTraits.sol";
+import { OpcodesDebug } from "../../contracts/opcodes/OpcodesDebug.sol";
+import { StaticBalances } from "../../contracts/instructions/Balances.sol";
+import { LimitSwap } from "../../contracts/instructions/LimitSwap.sol";
+import { OraclePriceAdjuster } from "../../contracts/instructions/OraclePriceAdjuster.sol";
+import { TokenMockDecimals } from "./mocks/TokenMockDecimals.sol";
+import { PriceOracleMock } from "./mocks/PriceOracleMock.sol";
+
+/**
+ * @title OraclePriceAdjusterTest
+ * @notice Tests for OraclePriceAdjuster on pairs whose tokens have different decimals
+ * @dev The swap price is computed from raw token amounts, so an 18/6 pair prices 1e12 below the
+ *      human-readable rate. These tests pin that the oracle answer is compared on that same scale.
+ */
+contract OraclePriceAdjusterTest is Test, OpcodesDebug {
+    Aqua public immutable aqua;
+    SwapVMRouter public swapVM;
+
+    TokenMockDecimals public weth;
+    TokenMockDecimals public usdc;
+    address public tokenA;
+    address public tokenB;
+    bool public wethIsA;
+
+    address public maker;
+    uint256 public makerPK = 0x1234;
+
+    uint8 public constant FEED_DECIMALS = 8;
+
+    /// 3000 USDC per WETH, in each side's own decimals
+    uint256 public constant WETH_RESERVE = 1000e18;
+    uint256 public constant USDC_RESERVE = 3_000_000e6;
+
+    /// One WETH in prices at exactly this, which is what makes the assertions exact
+    uint256 public constant EXPECTED_OUT = 3000e6;
+
+    function setUp() public {
+        maker = vm.addr(makerPK);
+        swapVM = new SwapVMRouter(address(aqua), address(0), address(this), "SwapVM", "1.0.0");
+
+        weth = new TokenMockDecimals("Wrapped Ether", "WETH", 18);
+        usdc = new TokenMockDecimals("USD Coin", "USDC", 6);
+
+        wethIsA = address(weth) < address(usdc);
+        (tokenA, tokenB) = wethIsA ? (address(weth), address(usdc)) : (address(usdc), address(weth));
+
+        weth.mint(maker, 10_000e18);
+        usdc.mint(maker, 30_000_000e6);
+        vm.prank(maker);
+        weth.approve(address(swapVM), type(uint256).max);
+        vm.prank(maker);
+        usdc.approve(address(swapVM), type(uint256).max);
+
+        weth.mint(address(this), 10_000e18);
+        weth.approve(address(swapVM), type(uint256).max);
+        usdc.approve(address(swapVM), type(uint256).max);
+    }
+
+    /// Without the adjuster, one WETH buys 3000 USDC. Everything below is read against this.
+    function test_OracleAdjusterBaselineWithoutOracle() public view {
+        assertEq(_quoteOneWeth(_program(address(0), 0)), EXPECTED_OUT, "curve alone");
+    }
+
+    /// A feed quoting the same price the curve does leaves the swap alone. Before the decimals were
+    /// part of the encoding this comparison ran 1e12 out and returned the cap instead.
+    function test_OracleAdjusterDoesNotAdjustWhenFeedMatchesCurve() public {
+        PriceOracleMock feed = new PriceOracleMock(3000e8, FEED_DECIMALS);
+        assertEq(_quoteOneWeth(_program(address(feed), 0)), EXPECTED_OUT, "no adjustment");
+    }
+
+    /// A feed above the curve moves the swap to the feed price, not to the cap.
+    function test_OracleAdjusterAppliesFeedPriceWhenBetter() public {
+        PriceOracleMock feed = new PriceOracleMock(3150e8, FEED_DECIMALS);
+        uint256 amountOut = _quoteOneWeth(_program(address(feed), 0));
+
+        assertGt(amountOut, EXPECTED_OUT, "the taker gets the feed price");
+        assertApproxEqRel(amountOut, 3150e6, 0.001e18, "and it is the feed price");
+        assertLt(amountOut, EXPECTED_OUT * 2, "not the cap");
+    }
+
+    /// Adjustment stays one directional: a feed below the curve is ignored.
+    function test_OracleAdjusterIgnoresWorseFeed() public {
+        PriceOracleMock feed = new PriceOracleMock(2800e8, FEED_DECIMALS);
+        assertEq(_quoteOneWeth(_program(address(feed), 0)), EXPECTED_OUT, "curve price kept");
+    }
+
+    /// maxPriceDecay still caps the adjustment.
+    function test_OracleAdjusterRespectsTheCap() public {
+        PriceOracleMock feed = new PriceOracleMock(6000e8, FEED_DECIMALS);
+        // maxIncrease = 2e18 - 0.9e18 = 1.1e18
+        uint256 amountOut = _quoteOneWeth(_program(address(feed), 0.9e18));
+
+        assertEq(amountOut, (EXPECTED_OUT * 1.1e18) / 1e18, "capped at 10 percent");
+    }
+
+    /// Scaling is exact on both sides of the exponent, including 18/18 where it is the old 1e18 rescale.
+    function test_ScaleAnswerMatchesTheRawUnitConvention() public pure {
+        assertEq(OraclePriceAdjuster.scaleAnswer(3000e8, 8, 18, 6), 3000e6, "18 in, 6 out");
+        assertEq(OraclePriceAdjuster.scaleAnswer(3000e8, 8, 6, 18), 3000e8 * 10 ** 22, "6 in, 18 out");
+        assertEq(OraclePriceAdjuster.scaleAnswer(3000e8, 8, 18, 18), 3000e8 * 10 ** 10, "18 and 18");
+    }
+
+    // --- helpers -----------------------------------------------------------------------------
+
+    function _program(address feed, uint64 maxPriceDecay) private view returns (bytes memory) {
+        bytes memory bytecode = bytes.concat(
+            wethIsA
+                ? StaticBalances.build(WETH_RESERVE, USDC_RESERVE)
+                : StaticBalances.build(USDC_RESERVE, WETH_RESERVE),
+            LimitSwap.build(address(weth), address(usdc))
+        );
+
+        if (feed == address(0)) return bytecode;
+
+        return bytes.concat(
+            bytecode,
+            OraclePriceAdjuster.build(maxPriceDecay, 3600, FEED_DECIMALS, 18, 6, feed)
+        );
+    }
+
+    function _quoteOneWeth(bytes memory program) private view returns (uint256 amountOut) {
+        ISwapVM.Order memory order = _createOrder(program);
+        (, amountOut,) = swapVM.asView().quote(order, 1e18, _signAndPackTakerData(order));
+    }
+
+    function _createOrder(bytes memory program) private view returns (ISwapVM.Order memory) {
+        return MakerTraitsLib.build(MakerTraitsLib.Args({
+            maker: maker,
+            tokenA: tokenA,
+            tokenB: tokenB,
+            shouldUnwrapWeth: false,
+            useAquaInsteadOfSignature: false,
+            allowZeroAmountIn: false,
+            receiver: address(0),
+            hasPreTransferInHook: false,
+            hasPostTransferInHook: false,
+            hasPreTransferOutHook: false,
+            hasPostTransferOutHook: false,
+            preTransferInTarget: address(0),
+            preTransferInData: "",
+            postTransferInTarget: address(0),
+            postTransferInData: "",
+            preTransferOutTarget: address(0),
+            preTransferOutData: "",
+            postTransferOutTarget: address(0),
+            postTransferOutData: "",
+            program: program
+        }));
+    }
+
+    function _signAndPackTakerData(ISwapVM.Order memory order) private view returns (bytes memory) {
+        bytes32 orderHash = swapVM.hash(order);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(makerPK, orderHash);
+
+        return TakerTraitsLib.build(TakerTraitsLib.Args({
+            taker: address(0),
+            isExactIn: true,
+            shouldUnwrapWeth: false,
+            isStrictThresholdAmount: false,
+            isFirstTransferFromTaker: false,
+            useTransferFromAndAquaPush: false,
+            isAToB: wethIsA,
+            allowPartialFill: false,
+            threshold: "",
+            to: address(this),
+            deadline: 0,
+            hasPreTransferInCallback: false,
+            hasPreTransferOutCallback: false,
+            preTransferInHookData: "",
+            postTransferInHookData: "",
+            preTransferOutHookData: "",
+            postTransferOutHookData: "",
+            preTransferInCallbackData: "",
+            preTransferOutCallbackData: "",
+            instructionsArgs: "",
+            signature: abi.encodePacked(r, s, v)
+        }));
+    }
+}

--- a/test/solidity/mocks/PriceOracleMock.sol
+++ b/test/solidity/mocks/PriceOracleMock.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: LicenseRef-Degensoft-SwapVM-1.1
+pragma solidity ^0.8.27;
+
+/// @custom:license-url https://github.com/1inch/swap-vm/blob/main/LICENSES/SwapVM-1.1.txt
+/// @custom:copyright © 2026 Degensoft Ltd
+
+import { IPriceOracle } from "../../../contracts/instructions/interfaces/IPriceOracle.sol";
+
+/**
+ * @title PriceOracleMock
+ * @dev Chainlink aggregator mock with a settable answer, for OraclePriceAdjuster tests
+ */
+contract PriceOracleMock is IPriceOracle {
+    int256 private _answer;
+    uint256 private _updatedAt;
+    uint8 private immutable _decimals;
+
+    constructor(int256 answer_, uint8 decimals_) {
+        _answer = answer_;
+        _decimals = decimals_;
+        _updatedAt = block.timestamp;
+    }
+
+    function setAnswer(int256 answer_, uint256 updatedAt_) external {
+        _answer = answer_;
+        _updatedAt = updatedAt_;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function description() external pure returns (string memory) {
+        return "PriceOracleMock";
+    }
+
+    function version() external pure returns (uint256) {
+        return 1;
+    }
+
+    function getRoundData(uint80 roundId_)
+        external
+        view
+        returns (uint80, int256, uint256, uint256, uint80)
+    {
+        return (roundId_, _answer, _updatedAt, _updatedAt, roundId_);
+    }
+
+    function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80) {
+        return (1, _answer, _updatedAt, _updatedAt, 1);
+    }
+}


### PR DESCRIPTION
Follow-up to #31, which reported the scale mismatch and was closed as out of focus. What that report
did not say is that it pays out rather than just misbehaving, so here is the fix in case it is worth
having.

`oraclePrice` is scaled to 1e18, `currentPrice` is `amountOut * 1e18 / amountIn` in raw token
amounts. Those agree only on an 18/18 pair. On 18/6 the swap price is 1e12 smaller, so
`oraclePrice > currentPrice` is true on every fill and `min(priceRatio, 2e18 - maxPriceDecay)`
returns the cap. With `maxPriceDecay = 0` that is 2x. There is no safe setting, since
`maxPriceDecay < ONE` is required at build.

The added test shows it. Reverting just the scaling line and rerunning gives:

```
1) test_ScaleAnswerMatchesTheRawUnitConvention()   3000000000000000000000 != 3000000000
2) test_OracleAdjusterIgnoresWorseFeed()           6000000000 != 3000000000
3) test_OracleAdjusterDoesNotAdjustWhenFeedMatchesCurve()  6000000000 != 3000000000
4) test_OracleAdjusterAppliesFeedPriceWhenBetter() 6000000000 !~= 3150000000
```

The fix scales to `10 ** (18 + tokenOutDecimals - tokenInDecimals)` instead. On an 18/18 pair that
exponent is 18, so nothing changes there. Decimals are declared in the program rather than read from
the tokens to keep two external calls off the hot path.

This changes the encoding, so it is breaking for anyone building the instruction today. Happy to do
it another way if you would rather not.

803 passing locally, up from 797. `.gas-snapshot` not regenerated; per AGENTS.md new functions are
informational there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes swap payout logic tied to oracle comparison and uses a breaking instruction encoding; incorrect decimals would mis-price adjustments, though the fix addresses a known overpayment on common decimal pairs.
> 
> **Overview**
> Fixes **OraclePriceAdjuster** comparing Chainlink answers at a fixed **1e18** scale while **currentPrice** uses raw **amountOut / amountIn**, which diverges on mixed-decimal pairs (e.g. 18/6) and could treat every fill as oracle-favorable—capping at up to **2×** output when **maxPriceDecay** is minimal.
> 
> The instruction encoding now includes **`tokenInDecimals`** and **`tokenOutDecimals`**, and **`scaleAnswer`** rescales the feed to **`10 ** (18 + tokenOutDecimals - tokenInDecimals)`** so it matches the swap price units (unchanged for 18/18 pairs). **`build` / `parse` / `sizeOf`** are updated accordingly—**breaking** for existing bytecode builders.
> 
> Adds **`PriceOracleMock`**, integration tests on a WETH/USDC-style pair (match feed, better/worse feed, cap), and unit tests for **`scaleAnswer`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 490941b6418d5ec298687fbef6ea61240392ce39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->